### PR TITLE
Fix bug during setup if existing .evergreen.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ git clone https://github.com/mongodb/server-workflow-tool
 cd server-workflow-tool
 pip3 install .
 
-# Create additional files needed by various configurations.
-touch ~/.evergreen.yml
-
 # Add the workflow tool to PATH.
 echo "source ~/.config/server-workflow-tool/profile" >> ~/.profile
 echo "source ~/.profile" >> ~/.bashrc

--- a/mongodb_cmdline_tool/setupenv.py
+++ b/mongodb_cmdline_tool/setupenv.py
@@ -206,8 +206,8 @@ def _set_evergreen_config(c):
               'continue')
         webbrowser.open('https://evergreen.mongodb.com/settings')
 
-        input('Once you have added your credentials to ~/.evergreen.yml and entered your user and '
-              'notification settings on the web UI, press any key to continue')
+        input('Once you have created ~/.evergreen.yml, added your credentials to it and entered '
+              'your user and notification settings on the web UI, press any key to continue')
 
     with open(pathlib.Path.home() / '.evergreen.yml') as evg_file:
         evg_config = yaml.load(evg_file)


### PR DESCRIPTION
Looks like my request to touch the .evergreen.yml file was incorrect.  From @aprilschoffer:

> The only small hiccup I ran into was in the server-workflow-tool installation: since we add a evergreen.yml file that's blank, you'll enter the if statement on line 202 in mongodb_cmdline_tool/setupenv.py to skip evergreen configuration, then hit an error on line 214 because the file is empty. It's not super obvious you have to copy your credentials first when you're just stepping through.

I think this PR fixes the issue by not creating the file first, and just telling people explicitly to do it later.  But open to other solutions.