### PR TITLE
EVG-8113 fix path

### DIFF
--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -31,7 +31,7 @@ setup_bash() {
         return
     fi
 
-    echo -e "\nsource $HOME/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
+    echo -e "\nsource $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
 
     source ~/.bash_profile
 }


### PR DESCRIPTION
Evergreen runs project setup commands under `~/<project_name>` so the repo will be checked out under the `mongodb-mongo-master` directory