### PR TITLE
EVG-8197 fix gdbinit

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -12,8 +12,11 @@ source .gdbinit
 # register boost pretty printers
 python
 import sys, pathlib
-sys.path.insert(1, os.path.join(pathlib.Path.home(), 'Boost-Pretty-Printer'))
-import boost
-boost.register_printers(boost_version=(1,60,0))
-print("Loaded boost pretty printers")
+try:
+    sys.path.insert(1, os.path.join(pathlib.Path.home(), 'Boost-Pretty-Printer'))
+    import boost
+    boost.register_printers(boost_version=(1,60,0))
+    print("Loaded boost pretty printers")
+except:
+    print("Failed to load the boost pretty printers")
 end


### PR DESCRIPTION
@visemet and I discovered 

- .gdbinit will stop executing when it hits an error
- `set scheduler-locking on` always errors in gdbinit

I'm removing the `set scheduler-locking on` line. Also skip loading the libstdc++ pretty printers since they're loaded in [buildscripts/gdb/mongo.py](https://github.com/mongodb/mongo/blob/87de9a0cb1e898d7b49c04558e60c40103ee1d8f/buildscripts/gdb/mongo.py#L15) which we're sourcing.