### PR TITLE
EVG-8197 fix python path

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -11,12 +11,18 @@ set print pretty on
 python
 import os, subprocess, sys
 try:
-    # Execute a Python using the user's shell and pull out the sys.path (for site-packages)
-    paths = subprocess.check_output('python -c "import os,sys;print(os.linesep.join(sys.path).strip())"',shell=True).decode("utf-8").split()
-    # Extend GDB's Python's search path
-    sys.path.extend(paths)
+    gdb_python_version = sys.version.split()[0]
+    shell_python_version = subprocess.check_output('python -c "import sys;print(sys.version.split()[0])"', shell=True).decode("utf-8").strip()
+    if gdb_python_version == shell_python_version:
+        # Execute a Python using the user's shell and pull out the sys.path (for site-packages)
+        shell_paths = subprocess.check_output('python -c "import os,sys;print(os.linesep.join(sys.path).strip())"', shell=True).decode("utf-8").split()
+        # Extend GDB's Python's search path
+        sys.path.extend(path for path in shell_paths if not path in sys.path)
+        print("Included venv Python path")
+    else:
+        print("Failed to include venv Python path: Python version mismatch (shell {}, gdb {})".format(shell_python_version, gdb_python_version))
 except Exception as e:
-    print("Failed to include venv Python path" + str(e))
+    print("Failed to include venv Python path: " + str(e))
 end
 
 # register boost pretty printers


### PR DESCRIPTION
#46 added pymongo to the toolchains Python3 install.
@guoyr raised objections. As an alternative, add the venv's path to the python path within GDB following the instructions [here](https://interrupt.memfault.com/blog/using-pypi-packages-with-GDB).

Also, I removed the `source .gdbinit` line since the [docs](https://sourceware.org/gdb/onlinedocs/gdb/Startup.html) say it happens by default.