### PR TITLE
EVG-8204 --jira-user

### DIFF
--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -6,7 +6,7 @@ import json
 import os
 import subprocess
 import psutil
-from argparse import ArgumentParser
+import argparse
 
 
 def set_password(args):
@@ -33,16 +33,19 @@ def create_cr(args):
 
     sys.path.append(os.path.expanduser(os.path.join("~", "kernel-tools", "codereview")))
     upload = importlib.import_module('upload')
-    upload.RealMain(["--check-clang-format", "--check-eslint", "--jira_user={}".format(os.getenv('JIRA_USERNAME'))])
+    upload.RealMain(["--check-clang-format", "--check-eslint", "--jira_user={}".format(os.getenv('JIRA_USERNAME'))] + args.additional_args)
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser()
+    parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(title="subcommands")
     pw_command = subparsers.add_parser("set-password", help="get a JIRA oauth token and store in the keyring")
     pw_command.set_defaults(func=set_password)
     pw_command.add_argument("generator_path", metavar="generator-path", help="path to the iteng-jira-repo")
 
-    subparsers.add_parser("create-cr", help="open a CR").set_defaults(func=create_cr)
+    cr_command = subparsers.add_parser("create-cr", help="open a CR")
+    cr_command.set_defaults(func=create_cr)
+    cr_command.add_argument("additional_args", metavar="additional-args", nargs=argparse.REMAINDER, help="arguments to pass to upload.py")
+
     args = parser.parse_args()
     args.func(args)

--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -1,32 +1,48 @@
 import sys
 import os.path as path
-import keyring
 import urllib.parse as urlparse
 import importlib
 import json
 import os
 import subprocess
+import psutil
+from argparse import ArgumentParser
 
-def set_password(generator_path):
-    os.chdir(generator_path)
-    sys.path.append(generator_path)
+
+def set_password(args):
+    os.chdir(args.generator_path)
+    sys.path.append(args.generator_path)
     tokengen = importlib.import_module('jira-token-gen')
 
     server_split = urlparse.urlparse(tokengen.access_token_url)
     server = urlparse.urlunparse((server_split.scheme, server_split.netloc, "", "", "", ""))
                                     
     password = {'access_token': tokengen.access_token['oauth_token'], 'access_token_secret': tokengen.access_token['oauth_token_secret']}
-    print("access_token: {}, secret: {}".format(tokengen.access_token['oauth_token'], tokengen.access_token['oauth_token_secret']))
-
     user = os.getenv('JIRA_USERNAME')
-    print("user: {}".format(user))
 
+    if not "gnome-keyring-daemon" in (p.name() for p in psutil.process_iter()):
+        subprocess.run(["gnome-keyring-daemon", "--unlock"], input="password", text=True)
+    import keyring
     keyring.set_password(server, user, json.dumps(password))
+    print("Password set in keyring for server: {}, user: {}".format(server, user))
+
+
+def create_cr(args):
+    if not "gnome-keyring-daemon" in (p.name() for p in psutil.process_iter()):
+        subprocess.run(["gnome-keyring-daemon", "--unlock"], input="password", text=True)
+
+    sys.path.append(os.path.expanduser(os.path.join("~", "kernel-tools", "codereview")))
+    upload = importlib.import_module('upload')
+    upload.RealMain(["--check-clang-format", "--check-eslint", "--jira_user={}".format(os.getenv('JIRA_USERNAME'))])
+
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        raise ValueError("expected one argument")
-    if not path.exists(sys.argv[1]):
-        raise ValueError("path '{}' does not exist".format(sys.argv[1]))
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(title="subcommands")
+    pw_command = subparsers.add_parser("set-password", help="get a JIRA oauth token and store in the keyring")
+    pw_command.set_defaults(func=set_password)
+    pw_command.add_argument("generator_path", metavar="generator-path", help="path to the iteng-jira-repo")
 
-    set_password(sys.argv[1])
+    subparsers.add_parser("create-cr", help="open a CR").set_defaults(func=create_cr)
+    args = parser.parse_args()
+    args.func(args)

--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -1,20 +1,32 @@
 import sys
+import os.path as path
 import keyring
-import urlparse
+import urllib.parse as urlparse
+import importlib
 import json
 import os
 import subprocess
 
-sys.path.append("iteng-jira-oauth")
-os.chdir("iteng-jira-oauth")
-import __builtin__
-# Line below is due to a bug in jira-token-gen
-__builtin__.input = __builtin__.raw_input
-tokengen = __import__('jira-token-gen', globals(), locals(), [], -1)
+def set_password(generator_path):
+    os.chdir(generator_path)
+    sys.path.append(generator_path)
+    tokengen = importlib.import_module('jira-token-gen')
 
-server_split = urlparse.urlparse(tokengen.access_token_url)
-server = urlparse.urlunparse((server_split.scheme, server_split.netloc, "", "", "", ""))
-                                 
-password = {'access_token': tokengen.access_token['oauth_token'], 'access_token_secret': tokengen.access_token['oauth_token_secret']}
-user = os.getenv('JIRA_USERNAME')
-keyring.set_password(server, user, json.dumps(password))
+    server_split = urlparse.urlparse(tokengen.access_token_url)
+    server = urlparse.urlunparse((server_split.scheme, server_split.netloc, "", "", "", ""))
+                                    
+    password = {'access_token': tokengen.access_token['oauth_token'], 'access_token_secret': tokengen.access_token['oauth_token_secret']}
+    print("access_token: {}, secret: {}".format(tokengen.access_token['oauth_token'], tokengen.access_token['oauth_token_secret']))
+
+    user = os.getenv('JIRA_USERNAME')
+    print("user: {}".format(user))
+
+    keyring.set_password(server, user, json.dumps(password))
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        raise ValueError("expected one argument")
+    if not path.exists(sys.argv[1]):
+        raise ValueError("path '{}' does not exist".format(sys.argv[1]))
+
+    set_password(sys.argv[1])

--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -1,0 +1,20 @@
+import sys
+import keyring
+import urlparse
+import json
+import os
+import subprocess
+
+sys.path.append("iteng-jira-oauth")
+os.chdir("iteng-jira-oauth")
+import __builtin__
+# Line below is due to a bug in jira-token-gen
+__builtin__.input = __builtin__.raw_input
+tokengen = __import__('jira-token-gen', globals(), locals(), [], -1)
+
+server_split = urlparse.urlparse(tokengen.access_token_url)
+server = urlparse.urlunparse((server_split.scheme, server_split.netloc, "", "", "", ""))
+                                 
+password = {'access_token': tokengen.access_token['oauth_token'], 'access_token_secret': tokengen.access_token['oauth_token_secret']}
+user = os.getenv('JIRA_USERNAME')
+keyring.set_password(server, user, json.dumps(password))

--- a/server_bashrc.sh
+++ b/server_bashrc.sh
@@ -12,7 +12,7 @@ function buildninjaic() {
         build.ninja
 }
 
-alias cr="~/kernel-tools/codereview/upload.py --check-clang-format --check-eslint --jira_user=$JIRA_USERNAME"
+alias cr="dbus-run-session -- python ~/mongodb-mongo-master/server-workflow-tool/jira_credentials.py create-cr"
 alias activate="source python3-venv/bin/activate"
 
 # gdb setup

--- a/server_bashrc.sh
+++ b/server_bashrc.sh
@@ -12,7 +12,7 @@ function buildninjaic() {
         build.ninja
 }
 
-alias cr="~/kernel-tools/codereview/upload.py --check-clang-format --check-eslint"
+alias cr="~/kernel-tools/codereview/upload.py --check-clang-format --check-eslint --jira_user=$JIRA_USERNAME"
 alias activate="source python3-venv/bin/activate"
 
 # gdb setup

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setuptools.setup(
         'keyring == 19.0.1',
         'invoke == 1.2.0',
         'pyyaml == 5.1',
-        'requests == 2.21.0'
+        'requests == 2.21.0',
+        'psutil == 5.7.0'
     ],
     entry_points={
         'console_scripts': ['workflow = serverworkflowtool.__main__:run'],

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,7 @@ setuptools.setup(
         'keyring == 19.0.1',
         'invoke == 1.2.0',
         'pyyaml == 5.1',
-        'requests == 2.21.0',
-        'psutil == 5.7.0'
+        'requests == 2.21.0'
     ],
     entry_points={
         'console_scripts': ['workflow = serverworkflowtool.__main__:run'],

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -30,7 +30,7 @@ setup_bash() {
     if [[ $ret = 0 ]]; then
         return
     fi
-    
+
     echo -e "\nsource $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
     source ~/.bash_profile
 }
@@ -103,8 +103,9 @@ setup_cr() {
 
 setup_jira_auth() {
     # Get the user's JIRA username
-    read -p "JIRA username: " jira_username
+    read -p "JIRA username (from https://jira.mongodb.org/secure/ViewProfile.jspa): " jira_username
     echo "export JIRA_USERNAME=$jira_username" >> ~/.bash_profile
+    echo "Wrote username \"$JIRA_USERNAME\" to ~/.bash_profile"
     export JIRA_USERNAME=$jira_username
 
     # Set up the Jira OAuth Token Generator repo
@@ -117,7 +118,7 @@ setup_jira_auth() {
         source venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r iteng-jira-oauth/requirements.txt
-            python -m pip install ./server-workflow-tool
+            python -m pip install keyring psutil
             dbus-run-session -- python server-workflow-tool/jira_credentials.py set-password $PWD/iteng-jira-oauth
         deactivate
     popd

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -31,7 +31,9 @@ setup_bash() {
         return
     fi
 
-    echo -e "\nsource $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
+    read -p "JIRA username: " jira_username
+    echo -e "\nexport JIRA_USERNAME=$jira_username" >> ~/.bash_profile
+    echo "source $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
 
     source ~/.bash_profile
 }

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -30,12 +30,28 @@ setup_bash() {
     if [[ $ret = 0 ]]; then
         return
     fi
-
-    read -p "JIRA username: " jira_username
-    echo -e "\nexport JIRA_USERNAME=$jira_username" >> ~/.bash_profile
-    echo "source $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
-
+    
+    echo -e "\nsource $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
     source ~/.bash_profile
+}
+
+setup_jira() {
+    # Get the user's JIRA username
+    read -p "JIRA username: " jira_username
+    echo "export JIRA_USERNAME=$jira_username" >> ~/.bash_profile
+    export JIRA_USERNAME=$jira_username
+
+    # Set up the Jira OAuth Token Generator repo
+    git clone git@github.com:10gen/iteng-jira-oauth.git
+    mkdir iteng-jira-oauth/venv
+    python3 -m venv iteng-jira-oauth/venv
+
+    # Get credentials and store them in the system keyring
+    source iteng-jira-oauth/venv/bin/activate
+        python -m pip install --upgrade pip
+        python -m pip install -r iteng-jira-oauth/requirements.txt
+        python jira_credentials.py
+    deactivate
 }
 
 setup_master() {
@@ -117,6 +133,7 @@ pushd $workdir
     ssh-keyscan github.com >> ~/.ssh/known_hosts
 
     setup_bash
+    setup_jira
     setup_master
     setup_44
     setup_cr

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -42,16 +42,19 @@ setup_jira() {
     export JIRA_USERNAME=$jira_username
 
     # Set up the Jira OAuth Token Generator repo
-    git clone git@github.com:10gen/iteng-jira-oauth.git
-    mkdir iteng-jira-oauth/venv
-    python3 -m venv iteng-jira-oauth/venv
+    pushd $HOME/mongodb-mongo-master
+        git clone git@github.com:10gen/iteng-jira-oauth.git
+        mkdir venv
+        /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
 
-    # Get credentials and store them in the system keyring
-    source iteng-jira-oauth/venv/bin/activate
-        python -m pip install --upgrade pip
-        python -m pip install -r iteng-jira-oauth/requirements.txt
-        python jira_credentials.py
-    deactivate
+        # Get credentials and store them in the system keyring
+        source venv/bin/activate
+            python -m pip install --upgrade pip
+            python -m pip install -r iteng-jira-oauth/requirements.txt
+            python -m pip install ./server-workflow-tool
+            python server-workflow-tool/jira_credentials.py $PWD/iteng-jira-oauth
+        deactivate
+    popd
 }
 
 setup_master() {

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -32,6 +32,7 @@ setup_bash() {
     fi
 
     echo -e "\nsource $HOME/mongodb-mongo-master/server-workflow-tool/server_bashrc.sh" >> ~/.bash_profile
+
     source ~/.bash_profile
 }
 

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -53,6 +53,7 @@ setup_master() {
             python -m pip install --upgrade pip
 
             python -m pip install -r etc/pip/dev-requirements.txt
+            python -m pip install keyring
 
             python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars compiledb
 
@@ -84,6 +85,7 @@ setup_44() {
             python -m pip install --upgrade pip
 
             python -m pip install -r etc/pip/dev-requirements.txt
+            python -m pip install keyring
 
             python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars compiledb
 

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -106,8 +106,8 @@ setup_jira_auth() {
     # Get the user's JIRA username
     read -p "JIRA username (from https://jira.mongodb.org/secure/ViewProfile.jspa): " jira_username
     echo "export JIRA_USERNAME=$jira_username" >> ~/.bash_profile
-    echo "Wrote username \"$JIRA_USERNAME\" to ~/.bash_profile"
     export JIRA_USERNAME=$jira_username
+    echo "Wrote username \"$JIRA_USERNAME\" to ~/.bash_profile"
 
     # Set up the Jira OAuth Token Generator repo
     pushd $HOME/mongodb-mongo-master

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -112,11 +112,11 @@ setup_jira_auth() {
     # Set up the Jira OAuth Token Generator repo
     pushd $HOME/mongodb-mongo-master
         git clone git@github.com:10gen/iteng-jira-oauth.git
-        mkdir venv
-        /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
+        mkdir iteng-jira-oauth/venv
+        /opt/mongodbtoolchain/v3/bin/python3 -m venv iteng-jira-oauth/venv
 
         # Get credentials and store them in the system keyring
-        source venv/bin/activate
+        source iteng-jira-oauth/venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r iteng-jira-oauth/requirements.txt
             python -m pip install keyring psutil


### PR DESCRIPTION
Providing the --jira-user option to upload.py will automatically comment on the ticket and transition it to "in code review."
Now that Evergreen [passes stdin though to the script](https://github.com/evergreen-ci/evergreen/pull/3715), we can ask the user for their JIRA username and guide them through the process of setting up a JIRA OAUTH token. We store the token in the user's keyring.

Because workstations are headless I wrote a script for adding the keys and creating a CR that follows the approach in the [keyring package's docs](https://pypi.org/project/keyring/#using-keyring-on-headless-linux-systems).

One challenge I don't have a good answer for: the gnome-keyring only opens with a password. Usually it repurposes the user's system password. I don't know that it's so terrible for it to use a bad password. No one else uses the system.