### PR TITLE
SERVER-56750: Add check for TODO comments to cr alias

### DIFF
--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -33,7 +33,7 @@ def create_cr(args, extra_args):
 
     sys.path.append(os.path.expanduser(os.path.join("~", "kernel-tools", "codereview")))
     upload = importlib.import_module('upload')
-    upload_args = ["--check-clang-format", "--check-eslint"]
+    upload_args = ["--check-clang-format", "--check-eslint", "--check-todos"]
     if os.getenv('JIRA_USERNAME') is not None:
         upload_args.append("--jira_user={}".format(os.getenv('JIRA_USERNAME')))
     upload.RealMain(upload_args + extra_args)


### PR DESCRIPTION
We recently added a script to check for open TODO comments to the server codebase and an option to the upload.py script to run that script. It was suggested to add this to the `cr` alias as well. 