### PR TITLE
TIG-3112 Check that there is actually a SSH key file

### DIFF
--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -16,7 +16,7 @@ set +e
 # we assume that if the user has non default SSH key filename they know about ssh-agent
 # and can set it up themselves
 for filename in ~/.ssh/id_*; do
-    [[ "$filename" == *".pub" ]] && continue
+    [[ -e "$filename" && "$filename" != *".pub" ]] || continue
     # check if SSH key has passphrase
     ssh-keygen -y -P "" -f "$filename" > /dev/null 2>&1
     [ $? -eq 0 ] && continue


### PR DESCRIPTION
While testing the message prompt with a fresh virtual workstation found an issue:
when there are no SSH key files the message is still prompted