### PR TITLE
Remove setup_jira_auth

### DIFF
--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -347,7 +347,12 @@ pushd "$workdir"
     sudo chown ubuntu /data/db
     ssh-keyscan github.com >> ~/.ssh/known_hosts 2>&1
 
+    # Do setup_bash first because it affects the environment, so later steps may
+    # depend on having the right PATH or other settings.
     setup_bash
+    # Do setup_jira_auth as early as possible, because it prompts the user to log
+    # in with Jira, which fails if they don't respond within a certain timeout.
+    # Doing this interactive step first means the rest of the script can run unattended.
     setup_jira_auth
     setup_master
     setup_60

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -348,10 +348,10 @@ pushd "$workdir"
     ssh-keyscan github.com >> ~/.ssh/known_hosts 2>&1
 
     setup_bash
+    setup_jira_auth
     setup_master
     setup_60
     setup_cr
-    setup_jira_auth
     setup_gdb
 
     setup_pipx


### PR DESCRIPTION
This script takes a while to run, and then prompts for user input when it gets to setup_jira_auth. If you don't respond in time, it fails. If you try to rerun it, it gets confused because the git clones it created already exist.

Instead if we put setup_jira_auth very early in the script, you're more likely to see the interactive part immediately. Then you can leave the rest of the script to run in the background.