### PR TITLE
SERVER-80793 Virtual workstation setup script works with poetry

### DIFF
--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -161,7 +161,7 @@ setup_master() {
             export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
             python -m poetry install --no-root --sync
 
-            python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb
+            python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb -j$(grep -c ^processor /proc/cpuinfo)
 
             buildninjaic
 
@@ -199,7 +199,7 @@ setup_70() {
 
             python -m pip install -r etc/pip/dev-requirements.txt
 
-            python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb
+            python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb -j$(grep -c ^processor /proc/cpuinfo)
 
             buildninjaic
 

--- a/virtual_workstation_setup.sh
+++ b/virtual_workstation_setup.sh
@@ -155,8 +155,11 @@ setup_master() {
 
             python -m pip install "pip==21.0.1"
 
-            python -m pip install -r etc/pip/dev-requirements.txt
-            python -m pip install keyring
+            python -m pip install 'poetry==1.5.1'
+            # PYTHON_KEYRING_BACKEND is needed to make poetry install work
+            # See guide https://wiki.corp.mongodb.com/display/KERNEL/Virtual+Workstation
+            export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+            python -m poetry install --no-root --sync
 
             python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb
 
@@ -195,7 +198,6 @@ setup_70() {
             python -m pip install --upgrade "pip==21.0.1"
 
             python -m pip install -r etc/pip/dev-requirements.txt
-            python -m pip install keyring
 
             python buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_clang.vars compiledb
 


### PR DESCRIPTION
Bug reported in #server-build-help. This will install poetry and run setup on master correctly. I also removed keyring since it is not needed for any part of the setup.

This PR contains two fixes SERVER-80793 and SERVER-80797. This is because the only way to test this is to merge these fixes. I would like to confirm they both work at the same time. I know it is annoying but since there are <10 lines of changes It would be good to review each one of these changes seperatly. I am taking Steve's LGTM as an LGTM on the first commit. I would like an LGTM on the second commit.